### PR TITLE
Fix `SQLCastExpression` for MySQL

### DIFF
--- a/Sources/SQLKitExtras/FluentSQLKitExtras/Expressions/SQLCast+FluentKeypaths.swift
+++ b/Sources/SQLKitExtras/FluentSQLKitExtras/Expressions/SQLCast+FluentKeypaths.swift
@@ -11,5 +11,14 @@ extension SQLExpression {
     ) -> Self where Self == SQLCastExpression {
         .cast(.column(column), to: type)
     }
+
+    /// Convenience method for creating a ``SQLCastExpression`` expression using a Fluent keypath for the value and an expression
+    /// for the desired type.
+    public static func cast(
+        _ column: KeyPath<some Schema, some QueryAddressableProperty>,
+        to type: some SQLExpression
+    ) -> Self where Self == SQLCastExpression {
+        .cast(.column(column), to: type)
+    }
 }
 #endif

--- a/Sources/SQLKitExtras/FluentSQLKitExtras/Expressions/SQLCast+FluentKeypaths.swift
+++ b/Sources/SQLKitExtras/FluentSQLKitExtras/Expressions/SQLCast+FluentKeypaths.swift
@@ -7,7 +7,7 @@ extension SQLExpression {
     /// for the desired type.
     public static func cast(
         _ column: KeyPath<some Schema, some QueryAddressableProperty>,
-        to type: String
+        to type: some StringProtocol
     ) -> Self where Self == SQLCastExpression {
         .cast(.column(column), to: type)
     }

--- a/Sources/SQLKitExtras/FluentSQLKitExtras/Expressions/SQLCast+FluentKeypaths.swift
+++ b/Sources/SQLKitExtras/FluentSQLKitExtras/Expressions/SQLCast+FluentKeypaths.swift
@@ -7,16 +7,7 @@ extension SQLExpression {
     /// for the desired type.
     public static func cast(
         _ column: KeyPath<some Schema, some QueryAddressableProperty>,
-        to type: some StringProtocol
-    ) -> Self where Self == SQLCastExpression {
-        .cast(.column(column), to: type)
-    }
-
-    /// Convenience method for creating a ``SQLCastExpression`` expression using a Fluent keypath for the value and an expression
-    /// for the desired type.
-    public static func cast(
-        _ column: KeyPath<some Schema, some QueryAddressableProperty>,
-        to type: some SQLExpression
+        to type: String
     ) -> Self where Self == SQLCastExpression {
         .cast(.column(column), to: type)
     }

--- a/Sources/SQLKitExtras/SQLKitExtras/Expressions/SQLCastExpression.swift
+++ b/Sources/SQLKitExtras/SQLKitExtras/Expressions/SQLCastExpression.swift
@@ -33,7 +33,7 @@ public struct SQLCastExpression: SQLExpression {
             serializer.dialect.name == "mysql",
             let ident = self.desiredType as? SQLIdentifier,
             ident.string.allSatisfy({ $0.isASCII && ($0.isLowercase || $0.isUppercase || $0.isWholeNumber || $0 == "_") })
-         {
+        {
             SQLRaw(ident.string)
         } else {
             self.desiredType
@@ -50,7 +50,7 @@ extension SQLExpression {
         _ column: some StringProtocol,
         to type: some StringProtocol
     ) -> Self where Self == SQLCastExpression {
-        .cast(.column(column), to: type)
+        .cast(.column(column), to: .identifier(type))
     }
 
     /// Convenience method for creating a ``SQLCastExpression`` using a column name and a string for the desired type.
@@ -58,7 +58,7 @@ extension SQLExpression {
         _ column: some SQLExpression,
         to type: some StringProtocol
     ) -> Self where Self == SQLCastExpression {
-        .init(column, to: type)
+        .cast(column, to: .identifier(type))
     }
 
     /// Convenience method for creating a ``SQLCastExpression`` using a column name and an expression for the desired type.

--- a/Sources/SQLKitExtras/SQLKitExtras/Expressions/SQLCastExpression.swift
+++ b/Sources/SQLKitExtras/SQLKitExtras/Expressions/SQLCastExpression.swift
@@ -6,31 +6,27 @@ public struct SQLCastExpression: SQLExpression {
     public let original: any SQLExpression
 
     /// The desired type to cast the original expression to.
-    public let desiredType: any SQLExpression
-
-    /// Create a new ``SQLCastExpression``.
-    ///
-    /// - Parameters:
-    ///   - original: The original expression to be cast.
-    ///   - desiredType: The desired type to cast the original expression to.
-    public init(expr: some SQLExpression, castType: some SQLExpression) {
-        self.original = expr
-        self.desiredType = castType
-    }
+    public let desiredType: String
 
     /// Convenience initializer for creating a ``SQLCastExpression`` with a string for the original expression and a string for the desired type.
     ///
     /// - Parameters:
     ///   - original: The original expression to be cast.
     ///   - desiredType: The desired type to cast the original expression to, represented as a string.
-    public init(_ original: some SQLExpression, to type: some StringProtocol) {
-        self.init(expr: original, castType: .identifier(type))
+    public init(_ original: some SQLExpression, to type: String) {
+        self.original = original
+        self.desiredType = type
     }
 
     /// See `SQLExpression.serialize(to:)`.
     public func serialize(to serializer: inout SQLSerializer) {
-        SQLFunction("CAST", args: SQLAlias(self.original, as: self.desiredType))
-            .serialize(to: &serializer)
+        if serializer.dialect.name == "mysql" {
+            SQLFunction("CAST", args: SQLAlias(self.original, as: SQLRaw(self.desiredType)))
+                .serialize(to: &serializer)
+        } else {
+            SQLFunction("CAST", args: SQLAlias(self.original, as: SQLIdentifier(self.desiredType)))
+                .serialize(to: &serializer)
+        }
     }
 }
 
@@ -38,24 +34,16 @@ extension SQLExpression {
     /// Convenience method for creating a ``SQLCastExpression`` using a column name and a string for the desired type.
     public static func cast(
         _ column: some StringProtocol,
-        to type: some StringProtocol
+        to type: String
     ) -> Self where Self == SQLCastExpression {
-        .cast(.column(column), to: .identifier(type))
+        .cast(.column(column), to: type)
     }
 
     /// Convenience method for creating a ``SQLCastExpression`` using a column name and a string for the desired type.
     public static func cast(
         _ column: some SQLExpression,
-        to type: some StringProtocol
+        to type: String
     ) -> Self where Self == SQLCastExpression {
-        .cast(column, to: .identifier(type))
-    }
-
-    /// Convenience method for creating a ``SQLCastExpression`` using a column name and an expression for the desired type.
-    public static func cast(
-        _ column: some SQLExpression,
-        to type: some SQLExpression
-    ) -> Self where Self == SQLCastExpression {
-        .init(expr: column, castType: type)
+        .init(column, to: type)
     }
 }

--- a/Sources/SQLKitExtras/SQLKitExtras/Expressions/SQLCastExpression.swift
+++ b/Sources/SQLKitExtras/SQLKitExtras/Expressions/SQLCastExpression.swift
@@ -6,27 +6,41 @@ public struct SQLCastExpression: SQLExpression {
     public let original: any SQLExpression
 
     /// The desired type to cast the original expression to.
-    public let desiredType: String
+    public let desiredType: any SQLExpression
+
+    /// Create a new ``SQLCastExpression``.
+    ///
+    /// - Parameters:
+    ///   - original: The original expression to be cast.
+    ///   - desiredType: The desired type to cast the original expression to.
+    public init(expr: some SQLExpression, castType: some SQLExpression) {
+        self.original = expr
+        self.desiredType = castType
+    }
 
     /// Convenience initializer for creating a ``SQLCastExpression`` with a string for the original expression and a string for the desired type.
     ///
     /// - Parameters:
     ///   - original: The original expression to be cast.
     ///   - desiredType: The desired type to cast the original expression to, represented as a string.
-    public init(_ original: some SQLExpression, to type: String) {
-        self.original = original
-        self.desiredType = type
+    public init(_ original: some SQLExpression, to type: some StringProtocol) {
+        self.init(expr: original, castType: .identifier(type))
     }
 
     /// See `SQLExpression.serialize(to:)`.
     public func serialize(to serializer: inout SQLSerializer) {
-        if serializer.dialect.name == "mysql" {
-            SQLFunction("CAST", args: SQLAlias(self.original, as: SQLRaw(self.desiredType)))
-                .serialize(to: &serializer)
+        let desiredType: any SQLExpression = if 
+            serializer.dialect.name == "mysql",
+            let ident = self.desiredType as? SQLIdentifier,
+            ident.string.allSatisfy({ $0.isASCII && ($0.isLowercase || $0.isUppercase || $0.isWholeNumber || $0 == "_") })
+         {
+            SQLRaw(ident.string)
         } else {
-            SQLFunction("CAST", args: SQLAlias(self.original, as: SQLIdentifier(self.desiredType)))
-                .serialize(to: &serializer)
+            self.desiredType
         }
+
+        SQLFunction("CAST", args: SQLAlias(self.original, as: desiredType))
+            .serialize(to: &serializer)
     }
 }
 
@@ -34,7 +48,7 @@ extension SQLExpression {
     /// Convenience method for creating a ``SQLCastExpression`` using a column name and a string for the desired type.
     public static func cast(
         _ column: some StringProtocol,
-        to type: String
+        to type: some StringProtocol
     ) -> Self where Self == SQLCastExpression {
         .cast(.column(column), to: type)
     }
@@ -42,8 +56,16 @@ extension SQLExpression {
     /// Convenience method for creating a ``SQLCastExpression`` using a column name and a string for the desired type.
     public static func cast(
         _ column: some SQLExpression,
-        to type: String
+        to type: some StringProtocol
     ) -> Self where Self == SQLCastExpression {
         .init(column, to: type)
+    }
+
+    /// Convenience method for creating a ``SQLCastExpression`` using a column name and an expression for the desired type.
+    public static func cast(
+        _ column: some SQLExpression,
+        to type: some SQLExpression
+    ) -> Self where Self == SQLCastExpression {
+        .init(expr: column, castType: type)
     }
 }

--- a/Tests/SQLKitExtrasTests/FluentSQLKitExtrasTests.swift
+++ b/Tests/SQLKitExtrasTests/FluentSQLKitExtrasTests.swift
@@ -302,12 +302,8 @@ struct FluentSQLKitExtrasTests {
         func castExpression() {
             #expect(serialize(.cast(\FooModel.$field, to: "text")) == #"CAST("foos"."field" AS "text")"#)
             
-            let mysqlDB = MockSQLDatabase(dialect: "mysql")
-            let castExpr: any SQLExpression = .cast(\FooModel.$field, to: "text")
-            #expect(mysqlDB.serialize(castExpr).sql == #"CAST("foos"."field" AS text)"#)
-            
-            let postgresDB = MockSQLDatabase(dialect: "postgresql")
-            #expect(postgresDB.serialize(castExpr).sql == #"CAST("foos"."field" AS "text")"#)
+            #expect(MockSQLDatabase(dialect: "mysql").serialize(.cast(\FooModel.$field, to: "text")).sql == #"CAST("foos"."field" AS text)"#)
+            #expect(MockSQLDatabase(dialect: "postgresql").serialize(.cast(\FooModel.$field, to: "text")).sql == #"CAST("foos"."field" AS "text")"#)
         }
     }
 }

--- a/Tests/SQLKitExtrasTests/FluentSQLKitExtrasTests.swift
+++ b/Tests/SQLKitExtrasTests/FluentSQLKitExtrasTests.swift
@@ -301,6 +301,7 @@ struct FluentSQLKitExtrasTests {
         @Test
         func castExpression() {
             #expect(serialize(.cast(\FooModel.$field, to: "text")) == #"CAST("foos"."field" AS "text")"#)
+            #expect(serialize(.cast(\FooModel.$field, to: .unsafeRaw("text"))) == #"CAST("foos"."field" AS text)"#)
             
             #expect(MockSQLDatabase(dialect: "mysql").serialize(.cast(\FooModel.$field, to: "text")).sql == #"CAST("foos"."field" AS text)"#)
             #expect(MockSQLDatabase(dialect: "postgresql").serialize(.cast(\FooModel.$field, to: "text")).sql == #"CAST("foos"."field" AS "text")"#)

--- a/Tests/SQLKitExtrasTests/FluentSQLKitExtrasTests.swift
+++ b/Tests/SQLKitExtrasTests/FluentSQLKitExtrasTests.swift
@@ -301,7 +301,13 @@ struct FluentSQLKitExtrasTests {
         @Test
         func castExpression() {
             #expect(serialize(.cast(\FooModel.$field, to: "text")) == #"CAST("foos"."field" AS "text")"#)
-            #expect(serialize(.cast(\FooModel.$field, to: .unsafeRaw("text"))) == #"CAST("foos"."field" AS text)"#)
+            
+            let mysqlDB = MockSQLDatabase(dialect: "mysql")
+            let castExpr: any SQLExpression = .cast(\FooModel.$field, to: "text")
+            #expect(mysqlDB.serialize(castExpr).sql == #"CAST("foos"."field" AS text)"#)
+            
+            let postgresDB = MockSQLDatabase(dialect: "postgresql")
+            #expect(postgresDB.serialize(castExpr).sql == #"CAST("foos"."field" AS "text")"#)
         }
     }
 }

--- a/Tests/SQLKitExtrasTests/SQLKitExtrasTests.swift
+++ b/Tests/SQLKitExtrasTests/SQLKitExtrasTests.swift
@@ -258,11 +258,8 @@ struct SQLKitExtrasTests {
             #expect(serialize(.cast("foo", to: "text")) == #"CAST("foo" AS "text")"#)
             #expect(serialize(.cast(.column("foo"), to: "text")) == #"CAST("foo" AS "text")"#)
 
-            let mysqlDB = MockSQLDatabase(dialect: "mysql")
-            #expect(mysqlDB.serialize(SQLCastExpression(.column("foo"), to: "text")).sql == #"CAST("foo" AS text)"#)
-
-            let postgresDB = MockSQLDatabase(dialect: "postgresql")
-            #expect(postgresDB.serialize(SQLCastExpression(.column("foo"), to: "text")).sql == #"CAST("foo" AS "text")"#)
+            #expect(MockSQLDatabase(dialect: "mysql").serialize(SQLCastExpression(.column("foo"), to: "text")).sql == #"CAST("foo" AS text)"#)
+            #expect(MockSQLDatabase(dialect: "postgresql").serialize(SQLCastExpression(.column("foo"), to: "text")).sql == #"CAST("foo" AS "text")"#)
         }
 
         @Test

--- a/Tests/SQLKitExtrasTests/SQLKitExtrasTests.swift
+++ b/Tests/SQLKitExtrasTests/SQLKitExtrasTests.swift
@@ -254,11 +254,15 @@ struct SQLKitExtrasTests {
         @Test
         func castExpression() {
             #expect(serialize(SQLCastExpression(.column("foo"), to: "text")) == #"CAST("foo" AS "text")"#)
-            #expect(serialize(SQLCastExpression(expr: .column("foo"), castType: .unsafeRaw("text"))) == #"CAST("foo" AS text)"#)
 
             #expect(serialize(.cast("foo", to: "text")) == #"CAST("foo" AS "text")"#)
             #expect(serialize(.cast(.column("foo"), to: "text")) == #"CAST("foo" AS "text")"#)
-            #expect(serialize(.cast(.column("foo"), to: .unsafeRaw("text"))) == #"CAST("foo" AS text)"#)
+
+            let mysqlDB = MockSQLDatabase(dialect: "mysql")
+            #expect(mysqlDB.serialize(SQLCastExpression(.column("foo"), to: "text")).sql == #"CAST("foo" AS text)"#)
+
+            let postgresDB = MockSQLDatabase(dialect: "postgresql")
+            #expect(postgresDB.serialize(SQLCastExpression(.column("foo"), to: "text")).sql == #"CAST("foo" AS "text")"#)
         }
 
         @Test

--- a/Tests/SQLKitExtrasTests/SQLKitExtrasTests.swift
+++ b/Tests/SQLKitExtrasTests/SQLKitExtrasTests.swift
@@ -254,9 +254,11 @@ struct SQLKitExtrasTests {
         @Test
         func castExpression() {
             #expect(serialize(SQLCastExpression(.column("foo"), to: "text")) == #"CAST("foo" AS "text")"#)
+            #expect(serialize(SQLCastExpression(expr: .column("foo"), castType: .unsafeRaw("text"))) == #"CAST("foo" AS text)"#)
 
             #expect(serialize(.cast("foo", to: "text")) == #"CAST("foo" AS "text")"#)
             #expect(serialize(.cast(.column("foo"), to: "text")) == #"CAST("foo" AS "text")"#)
+            #expect(serialize(.cast(.column("foo"), to: .unsafeRaw("text"))) == #"CAST("foo" AS text)"#)
 
             #expect(MockSQLDatabase(dialect: "mysql").serialize(SQLCastExpression(.column("foo"), to: "text")).sql == #"CAST("foo" AS text)"#)
             #expect(MockSQLDatabase(dialect: "postgresql").serialize(SQLCastExpression(.column("foo"), to: "text")).sql == #"CAST("foo" AS "text")"#)


### PR DESCRIPTION
Currently `SQLCastExpression` doesn't work on MySQL because of syntax differences. This fixes it.