### PR TITLE
Add variadic `columns(of:, ...)` helpers in several places.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
         swift:
           - swift:6.0-noble
           - swift:6.1-noble
+          - swift:6.2-noble
     runs-on: ubuntu-latest
     container: ${{ matrix.swift }}
     steps:
@@ -24,9 +25,9 @@ jobs:
         uses: actions/checkout@v5
       - name: Run unit tests
         env:
-          TRAITS_FLAG: ${{ matrix.swift == 'swift:6.1-noble' && '--enable-all-traits' || '' }}
+          TRAITS_FLAG: ${{ matrix.swift != 'swift:6.0-noble' && '--enable-all-traits' || '' }}
         run: |
-          swift test --enable-code-coverage -Xswiftc -warnings-as-errors ${TRAITS_FLAG}
+          swift test --enable-code-coverage --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors ${TRAITS_FLAG}
       - name: Upload coverage data
         uses: vapor/swift-codecov-action@v0.3
         with:
@@ -40,6 +41,8 @@ jobs:
         include:
           - macos-version: macos-15
             xcode-version: latest-stable
+          - macos-version: macos-26
+            xcode-version: latest-stable
     runs-on: ${{ matrix.macos-version }}
     steps:
       - name: Select appropriate Xcode version
@@ -50,7 +53,7 @@ jobs:
         uses: actions/checkout@v5
       - name: Run unit tests
         run: |
-          swift test --enable-code-coverage -Xswiftc -warnings-as-errors --enable-all-traits
+          swift test --enable-code-coverage --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors --enable-all-traits
       - name: Upload coverage data
         uses: vapor/swift-codecov-action@v0.3
         with:
@@ -58,21 +61,3 @@ jobs:
 
   # Can't test on Windows, uses NIO
   # Can't test Musl because of FluentBenchmarks and SQLKitBenchmarks
-  
-  #android-unit:
-  #  if: ${{ !(github.event.pull_request.draft || false) }}
-  #  strategy:
-  #    fail-fast: false
-  #    matrix:
-  #      swift-version:
-  #        - 6.1
-  #  runs-on: ubuntu-latest
-  #  timeout-minutes: 60
-  #  steps:
-  #    - name: Check out code
-  #      uses: actions/checkout@v4
-  #    - name: Run unit tests
-  #      uses: skiptools/swift-android-action@v2
-  #      with:
-  #        swift-version: ${{ matrix.swift-version }}
-  #        swift-test-flags: --enable-all-traits

--- a/Sources/SQLKitExtras/FluentSQLKitExtras/Builders/SQLInsertBuilder+FluentKeypaths.swift
+++ b/Sources/SQLKitExtras/FluentSQLKitExtras/Builders/SQLInsertBuilder+FluentKeypaths.swift
@@ -21,7 +21,7 @@ extension SQLInsertBuilder {
 
     /// Allow specifying a set of unqualified column names for an insert builder using Fluent model keypaths which all
     /// belong to the same model. This is identical to ``columns<each Schema, each QueryAddressableProperty>(_: repeat...)``,
-    /// except that on that method, each KeyPath can refer to a different Schema,forcing the caller to specify the root
+    /// except that on that method, each KeyPath can refer to a different Schema, forcing the caller to specify the root
     /// type on all of them. However, it is a very common use case to specify many keypaths from the same model in a row,
     /// e.g., `.columns(\MyModel.$foo, \MyModel.$bar, \MyModel.$baz, \MyModel.$bam)`. This quickly becomes quite tedious.
     /// By contrast, this method accepts only a single `Schema` type, and all KeyPaths are assumed to refer to it, allowing

--- a/Sources/SQLKitExtras/FluentSQLKitExtras/Builders/SQLInsertBuilder+FluentKeypaths.swift
+++ b/Sources/SQLKitExtras/FluentSQLKitExtras/Builders/SQLInsertBuilder+FluentKeypaths.swift
@@ -19,6 +19,25 @@ extension SQLInsertBuilder {
         return self
     }
 
+    /// Allow specifying a set of unqualified column names for an insert builder using Fluent model keypaths which all
+    /// belong to the same model. This is identical to ``columns<each Schema, each QueryAddressableProperty>(_: repeat...)``,
+    /// except that on that method, each KeyPath can refer to a different Schema,forcing the caller to specify the root
+    /// type on all of them. However, it is a very common use case to specify many keypaths from the same model in a row,
+    /// e.g., `.columns(\MyModel.$foo, \MyModel.$bar, \MyModel.$baz, \MyModel.$bam)`. This quickly becomes quite tedious.
+    /// By contrast, this method accepts only a single `Schema` type, and all KeyPaths are assumed to refer to it, allowing
+    /// the previous example to be written as `.columns(of: MyModel.self, \.$bar, \.$baz, \.$bam)`. As with all other
+    /// `.columns()` methods of `SQLInsertBuilder`, this method _replaces_ all existing columns.
+    @discardableResult
+    public func columns<S: Schema, each P: QueryAddressableProperty>(
+        of: S.Type, _ keypaths: repeat KeyPath<S, each P>
+    ) -> Self {
+        self.insert.columns = []
+        for keypath in repeat each keypaths {
+          self.insert.columns.append(.identifier(keypath))
+        }
+        return self
+    }
+
     /// Allow specifying a column or columns for ignoring insert conflicts using Fluent model keypaths.
     @discardableResult
     public func ignoringConflicts<each F: Fields, each P: QueryAddressableProperty>(with keypaths: repeat KeyPath<each F, each P>) -> Self {

--- a/Sources/SQLKitExtras/FluentSQLKitExtras/Builders/SQLUnqualifiedColumnListBuilder+FluentKeypaths.swift
+++ b/Sources/SQLKitExtras/FluentSQLKitExtras/Builders/SQLUnqualifiedColumnListBuilder+FluentKeypaths.swift
@@ -23,5 +23,22 @@ extension SQLUnqualifiedColumnListBuilder {
         repeat _ = self.column(each keypaths)
         return self
     }
+
+    /// Despite the name of the builder protocol, this method specifies a variable number of _fully qualified_ columns
+    /// using Fluent model keypaths. To specify _unqualified_ columns with keypaths, consider using
+    /// `SQLUnqualifiedColumnListBuilder.column(.identifier(\Model.$property))`. This is identical to
+    /// ``columns<each Schema, each QueryAddressableProperty>(_: repeat...)``, except that on that method, each KeyPath
+    /// can refer to a different Schema,forcing the caller to specify the root type on all of them. However, it is a very
+    /// common use case to specify many keypaths from the same model in a row, e.g.,
+    /// `.columns(\MyModel.$foo, \MyModel.$bar, \MyModel.$baz, \MyModel.$bam)`. This quickly becomes quite tedious. By
+    /// contrast, this method accepts only a single `Schema` type, and all KeyPaths are assumed to refer to it, allowing
+    /// the previous example to be written as `.columns(of: MyModel.self, \.$bar, \.$baz, \.$bam)`.
+    @discardableResult
+    public func columns<S: Schema, each P: QueryAddressableProperty>(
+        of: S.Type, _ keypaths: repeat KeyPath<S, each P>
+    ) -> Self {
+        repeat _ = self.column(each keypaths)
+        return self
+    }
 }
 #endif

--- a/Sources/SQLKitExtras/FluentSQLKitExtras/Builders/SQLUnqualifiedColumnListBuilder+FluentKeypaths.swift
+++ b/Sources/SQLKitExtras/FluentSQLKitExtras/Builders/SQLUnqualifiedColumnListBuilder+FluentKeypaths.swift
@@ -28,7 +28,7 @@ extension SQLUnqualifiedColumnListBuilder {
     /// using Fluent model keypaths. To specify _unqualified_ columns with keypaths, consider using
     /// `SQLUnqualifiedColumnListBuilder.column(.identifier(\Model.$property))`. This is identical to
     /// ``columns<each Schema, each QueryAddressableProperty>(_: repeat...)``, except that on that method, each KeyPath
-    /// can refer to a different Schema,forcing the caller to specify the root type on all of them. However, it is a very
+    /// can refer to a different Schema, forcing the caller to specify the root type on all of them. However, it is a very
     /// common use case to specify many keypaths from the same model in a row, e.g.,
     /// `.columns(\MyModel.$foo, \MyModel.$bar, \MyModel.$baz, \MyModel.$bam)`. This quickly becomes quite tedious. By
     /// contrast, this method accepts only a single `Schema` type, and all KeyPaths are assumed to refer to it, allowing

--- a/Sources/SQLKitExtras/FluentSQLKitExtras/SQLQueryFetcher+FluentKeypaths.swift
+++ b/Sources/SQLKitExtras/FluentSQLKitExtras/SQLQueryFetcher+FluentKeypaths.swift
@@ -40,6 +40,42 @@ extension SQLQueryFetcher {
         }
     }
 
+    /// For each keypath in an arbitrary list of Fluent model keypaths, decodes the appropriate column from the result
+    /// row (if any), returning the combined results as a tuple where the types of each item of the tuple are inferred
+    /// from the property referenced by the corresponding keypath. If the query produced no results, `nil` is returned.
+    /// This is identical to ``first<each Schema, each QueryAddressableProperty>(decodingColumns: repeat...)``, except
+    /// that on that method, each KeyPath can refer to a different Schema,forcing the caller to specify the root type on
+    /// all of them. However, it is a very common use case to specify many keypaths from the same model in a row, e.g.,
+    /// `.first(decodingColumns: \MyModel.$foo, \MyModel.$bar, \MyModel.$baz, \MyModel.$bam)`. This quickly becomes quite
+    /// tedious. By contrast, this method accepts only a single `Schema` type, and all KeyPaths are assumed to refer to
+    /// it, allowing the previous example to be written as `.first(decodingColumnsOf: MyModel.self, \.$bar, \.$baz, \.$bam)`.
+    ///
+    /// Example:
+    ///
+    /// ```swift
+    /// final class MyModel: FluentKit.Model, @unchecked Sendable {
+    ///     @ID(custom: .id) var id: Int?
+    ///     @Field(key: "field1") var field1: String
+    ///     @Parent(key: "parent_id") var parent: ParentModel
+    ///     @Enum(key: "field2") var field2: SomeEnum
+    ///     init() {}
+    /// }
+    ///
+    /// let tuple/*(id, field1, parentId, field2)*/ = try await sqlDatabase.select()
+    ///     .columns(\MyModel.$id, \MyModel.$field1, \MyModel.$parent, \MyModel.$field2)
+    ///     .from(MyModel.self)
+    ///     .first(decodingColumns: \MyModel.$id, \MyModel$field1, \MyModel.$parent, \MyModel.$field2)
+    ///
+    /// // type(of: tuple) == (Int, String, ParentModel.IDValue, SomeEnum).self
+    /// ```
+    public func first<S: Schema, each P: QueryAddressableProperty>(
+        decodingColumnsOf: S.Type, _ keypaths: repeat KeyPath<S, each P>
+    ) async throws -> (repeat (each P).QueryablePropertyType.Value)? {
+        try await self.first().map {
+            try $0.decode(columnsOf: S.self, repeat each keypaths)
+        }
+    }
+
     /// Allow specifying a Fluent model keypath as a column name when decoding multiple query fetcher results.
     public func all<M: Schema, P: QueryAddressableProperty>(
         decodingColumn keypath: KeyPath<M, P>
@@ -74,6 +110,42 @@ extension SQLQueryFetcher {
     ) async throws -> [(repeat (each P).QueryablePropertyType.Value)] {
         try await self.all().map {
             try $0.decode(columns: repeat each keypaths)
+        }
+    }
+
+    /// For each keypath in an arbitrary list of Fluent model keypaths, decodes the appropriate column from each result
+    /// row, returning the combined results as an array of tuples where the types of each item of the tuple are inferred
+    /// from the property referenced by the corresponding keypath. This is identical to
+    /// ``all<each Schema, each QueryAddressableProperty>(decodingColumns: repeat...)``, except that on that method, each
+    /// KeyPath can refer to a different Schema,forcing the caller to specify the root type on all of them. However, it is
+    /// a very common use case to specify many keypaths from the same model in a row, e.g.,
+    /// `.all(decodingColumns: \MyModel.$foo, \MyModel.$bar, \MyModel.$baz, \MyModel.$bam)`. This quickly becomes quite
+    /// tedious. By contrast, this method accepts only a single `Schema` type, and all KeyPaths are assumed to refer to
+    /// it, allowing the previous example to be written as `.all(decodingColumnsOf: MyModel.self, \.$bar, \.$baz, \.$bam)`.
+    ///
+    /// Example:
+    ///
+    /// ```swift
+    /// final class MyModel: FluentKit.Model, @unchecked Sendable {
+    ///     @ID(custom: .id) var id: Int?
+    ///     @Field(key: "field1") var field1: String
+    ///     @Parent(key: "parent_id") var parent: ParentModel
+    ///     @Enum(key: "field2") var field2: SomeEnum
+    ///     init() {}
+    /// }
+    ///
+    /// let tuples = try await sqlDatabase.select()
+    ///     .columns(\MyModel.$id, \MyModel.$field1, \MyModel.$parent, \MyModel.$field2)
+    ///     .from(MyModel.self)
+    ///     .all(decodingColumns: \MyModel.$id, \MyModel$field1, \MyModel.$parent, \MyModel.$field2)
+    ///
+    /// // type(of: tuples) == Array<(Int, String, ParentModel.IDValue, SomeEnum)>.self
+    /// ```
+    public func all<S: Schema, each P: QueryAddressableProperty>(
+        decodingColumnsOf: S.Type, _ keypaths: repeat KeyPath<S, each P>
+    ) async throws -> [(repeat (each P).QueryablePropertyType.Value)] {
+        try await self.all().map {
+            try $0.decode(columnsOf: S.self, repeat each keypaths)
         }
     }
 }

--- a/Sources/SQLKitExtras/FluentSQLKitExtras/SQLQueryFetcher+FluentKeypaths.swift
+++ b/Sources/SQLKitExtras/FluentSQLKitExtras/SQLQueryFetcher+FluentKeypaths.swift
@@ -44,7 +44,7 @@ extension SQLQueryFetcher {
     /// row (if any), returning the combined results as a tuple where the types of each item of the tuple are inferred
     /// from the property referenced by the corresponding keypath. If the query produced no results, `nil` is returned.
     /// This is identical to ``first<each Schema, each QueryAddressableProperty>(decodingColumns: repeat...)``, except
-    /// that on that method, each KeyPath can refer to a different Schema,forcing the caller to specify the root type on
+    /// that on that method, each KeyPath can refer to a different Schema, forcing the caller to specify the root type on
     /// all of them. However, it is a very common use case to specify many keypaths from the same model in a row, e.g.,
     /// `.first(decodingColumns: \MyModel.$foo, \MyModel.$bar, \MyModel.$baz, \MyModel.$bam)`. This quickly becomes quite
     /// tedious. By contrast, this method accepts only a single `Schema` type, and all KeyPaths are assumed to refer to
@@ -117,7 +117,7 @@ extension SQLQueryFetcher {
     /// row, returning the combined results as an array of tuples where the types of each item of the tuple are inferred
     /// from the property referenced by the corresponding keypath. This is identical to
     /// ``all<each Schema, each QueryAddressableProperty>(decodingColumns: repeat...)``, except that on that method, each
-    /// KeyPath can refer to a different Schema,forcing the caller to specify the root type on all of them. However, it is
+    /// KeyPath can refer to a different Schema, forcing the caller to specify the root type on all of them. However, it is
     /// a very common use case to specify many keypaths from the same model in a row, e.g.,
     /// `.all(decodingColumns: \MyModel.$foo, \MyModel.$bar, \MyModel.$baz, \MyModel.$bam)`. This quickly becomes quite
     /// tedious. By contrast, this method accepts only a single `Schema` type, and all KeyPaths are assumed to refer to

--- a/Sources/SQLKitExtras/FluentSQLKitExtras/SQLRow+FluentKeypaths.swift
+++ b/Sources/SQLKitExtras/FluentSQLKitExtras/SQLRow+FluentKeypaths.swift
@@ -57,5 +57,44 @@ extension SQLRow {
     ) throws -> (repeat (each P).QueryablePropertyType.Value) {
         (repeat try self.decode(column: each keypaths))
     }
+
+    /// For each keypath in an arbitrary list of Fluent model keypaths, decode the appropriate column from the
+    /// `SQLRow`, returning the combined results as a tuple where the types of each item of the tuple are inferred
+    /// from the property referenced by the corresponding keypath. This is identical to
+    /// ``decode<each Schema, each QueryAddressableProperty>(decodingColumns: repeat...)``, except that on that method,
+    /// each KeyPath can refer to a different Schema,forcing the caller to specify the root type on all of them. However,
+    /// it is a very common use case to specify many keypaths from the same model in a row, e.g.,
+    /// `.decode(columns: \MyModel.$foo, \MyModel.$bar, \MyModel.$baz, \MyModel.$bam)`. This quickly becomes quite
+    /// tedious. By contrast, this method accepts only a single `Schema` type, and all KeyPaths are assumed to refer to
+    /// it, allowing the previous example to be written as `.decode(columnsOf: MyModel.self, \.$bar, \.$baz, \.$bam)`.
+    ///
+    /// Example:
+    ///
+    /// ```swift
+    /// final class MyModel: FluentKit.Model, @unchecked Sendable {
+    ///     @ID(custom: .id) var id: Int?
+    ///     @Field(key: "field1") var field1: String
+    ///     @Parent(key: "parent_id") var parent: ParentModel
+    ///     @Enum(key: "field2") var field2: SomeEnum
+    ///     init() {}
+    /// }
+    ///
+    /// let rows = try await sqlDatabase.select()
+    ///     .columns(\MyModel.$id, \MyModel.$field1, \MyModel.$parent, \MyModel.$field2)
+    ///     .from(MyModel.self)
+    ///     .all()
+    ///
+    /// for row in rows {
+    ///     let tuple/*(id, field1, parentId, field2)*/ = try row.decode(columns:
+    ///         \MyModel.$id, \MyModel$field1, \MyModel.$parent, \MyModel.$field2
+    ///     )
+    ///     // type(of: tuple) == (Int, String, ParentModel.IDValue, SomeEnum).self
+    /// }
+    /// ```
+    public func decode<S: Schema, each P: QueryAddressableProperty>(
+        columnsOf: S.Type, _ keypaths: repeat KeyPath<S, each P>
+    ) throws -> (repeat (each P).QueryablePropertyType.Value) {
+        (repeat try self.decode(column: each keypaths))
+    }
 }
 #endif

--- a/Sources/SQLKitExtras/FluentSQLKitExtras/SQLRow+FluentKeypaths.swift
+++ b/Sources/SQLKitExtras/FluentSQLKitExtras/SQLRow+FluentKeypaths.swift
@@ -62,7 +62,7 @@ extension SQLRow {
     /// `SQLRow`, returning the combined results as a tuple where the types of each item of the tuple are inferred
     /// from the property referenced by the corresponding keypath. This is identical to
     /// ``decode<each Schema, each QueryAddressableProperty>(decodingColumns: repeat...)``, except that on that method,
-    /// each KeyPath can refer to a different Schema,forcing the caller to specify the root type on all of them. However,
+    /// each KeyPath can refer to a different Schema, forcing the caller to specify the root type on all of them. However,
     /// it is a very common use case to specify many keypaths from the same model in a row, e.g.,
     /// `.decode(columns: \MyModel.$foo, \MyModel.$bar, \MyModel.$baz, \MyModel.$bam)`. This quickly becomes quite
     /// tedious. By contrast, this method accepts only a single `Schema` type, and all KeyPaths are assumed to refer to

--- a/Tests/SQLKitExtrasTests/FluentSQLKitExtrasTests.swift
+++ b/Tests/SQLKitExtrasTests/FluentSQLKitExtrasTests.swift
@@ -81,6 +81,7 @@ struct FluentSQLKitExtrasTests {
             #expect(throws: Never.self) { () throws in #expect(try ([:] as ThinSQLRow).decodeNil(column: \FooModel.$id)) }
             #expect(throws: Never.self) { () throws in #expect(try (["field": "foo"] as ThinSQLRow).decode(column: \FooModel.$field) == "foo") }
             #expect(throws: Never.self) { () throws in #expect(try (["field": "", "parent_id": 1] as ThinSQLRow).decode(columns: \FooModel.$field, \FooModel.$parent) == ("", 1)) }
+            #expect(throws: Never.self) { () throws in #expect(try (["field": "", "parent_id": 1] as ThinSQLRow).decode(columnsOf: FooModel.self, \.$field, \.$parent) == ("", 1)) }
         }
 
         @Test
@@ -92,12 +93,19 @@ struct FluentSQLKitExtrasTests {
                 #expect(try await MockSQLDatabase(resultSet: [["field": "a", "parent_id": 1]]).select()
                     .first(decodingColumns: \FooModel.$field, \FooModel.$parent) ?? ("", 0) == ("a", 1))
             }
+            await #expect(throws: Never.self) { () async throws in
+                #expect(try await MockSQLDatabase(resultSet: [["field": "a", "parent_id": 1]]).select()
+                    .first(decodingColumnsOf: FooModel.self, \.$field, \.$parent) ?? ("", 0) == ("a", 1))
+            }
 
             await #expect(throws: Never.self) { () async throws in
                 #expect(try await MockSQLDatabase(resultSet: [["field": "a"], ["field": "b"]]).select().all(decodingColumn: \FooModel.$field) == ["a", "b"])
             }
             await #expect(throws: Never.self) { () async throws in
                 #expect(try await MockSQLDatabase(resultSet: [["field": "a"], ["field": "b"]]).select().all(decodingColumns: \FooModel.$field) == ["a", "b"])
+            }
+            await #expect(throws: Never.self) { () async throws in
+                #expect(try await MockSQLDatabase(resultSet: [["field": "a"], ["field": "b"]]).select().all(decodingColumnsOf: FooModel.self, \.$field) == ["a", "b"])
             }
         }
     }
@@ -164,6 +172,7 @@ struct FluentSQLKitExtrasTests {
         @Test
         func insertBuilderExtensions() {
             #expect(serialize(MockSQLDatabase().insert(into: FooModel.self).columns(\FooModel.$field, \FooModel.$parent)) == #"INSERT INTO "foos" ("field", "parent_id")"#)
+            #expect(serialize(MockSQLDatabase().insert(into: FooModel.self).columns(of: FooModel.self, \.$field, \.$parent)) == #"INSERT INTO "foos" ("field", "parent_id")"#)
             #expect(serialize(MockSQLDatabase().insert(into: FooModel.self).ignoringConflicts(with: \FooModel.$field)) == #"INSERT INTO "foos" () ON CONFLICT ("field") DO NOTHING"#)
             #expect(serialize(MockSQLDatabase().insert(into: FooModel.self).onConflict(with: \FooModel.$field, do: { $0 })) == #"INSERT INTO "foos" () ON CONFLICT ("field") DO UPDATE SET"#)
         }
@@ -251,6 +260,7 @@ struct FluentSQLKitExtrasTests {
         func unqualifiedColumnListBuilderExtensions() {
             #expect(serialize(selectBuilder().column(\FooModel.$field)) == #"SELECT "foos"."field""#)
             #expect(serialize(selectBuilder().columns(\FooModel.$field, \FooModel.$id)) == #"SELECT "foos"."field", "foos"."id""#)
+            #expect(serialize(selectBuilder().columns(of: FooModel.self, \.$field, \.$id)) == #"SELECT "foos"."field", "foos"."id""#)
         }
 
         @Test


### PR DESCRIPTION
Add several new helpers:

- `SQLRow.decode(columnsOf:_:)`
- `SQLQueryFetcher.first(decodingColumnsOf:_:)`
- `SQLQueryFetcher.all(decodingColumnsOf:_:)`
- `SQLUnqualifiedColumnListBuilder.columns(of:_:)`
- `SQLInsertBuilder.columns(of:_:)`

These helpers work exactly the same as the variadic `.columns(_:)` helpers, allowing you to specify multiple Fluent key paths in one call, except that these helpers require you to specify a single model at the start of the list to which all of the key paths apply. In other words, this line:
```swift
insert.column(of: FooModel.self, \.$field1, \.$field2, \.$field3)
```
is exactly the same as this line:
```swift
insert.columns(\FooModel.$field1, \FooModel.$field2, \FooModel.$field3)
```
Which style you prefer when dealing with lots of columns from the same model is up to you; there is no difference in behavior or performance.